### PR TITLE
fix undefined variables

### DIFF
--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -3957,6 +3957,7 @@ def generic_call(self, *inputs, **kwargs):
             self.standard_broadcasting)
         vinputs, valid_ind, allout = prepare_bounding_box_inputs(
                                         self, input_shape, inputs, bbox)
+        valid_result_unit = None
         if not allout:
             valid_result = self.evaluate(*chain(vinputs, parameters))
             valid_result_unit = getattr(valid_result, 'unit', None)

--- a/astropy/modeling/polynomial.py
+++ b/astropy/modeling/polynomial.py
@@ -13,7 +13,7 @@ from .functional_models import Shift
 from .parameters import Parameter
 from .utils import poly_map_domain, comb
 from astropy.utils import indent, check_broadcast
-from astropy.units import Quantity
+
 
 __all__ = [
     'Chebyshev1D', 'Chebyshev2D', 'Hermite1D', 'Hermite2D',

--- a/astropy/modeling/tests/test_compound.py
+++ b/astropy/modeling/tests/test_compound.py
@@ -555,6 +555,7 @@ def test_bounding_box():
     val3 = g(.1, .1, with_bounding_box=True)
 
 
+@pytest.mark.skipif("not HAS_SCIPY_14")
 def test_bounding_box_with_units():
     points = np.arange(5) * u.pix
     lt = np.arange(5) * u.AA

--- a/astropy/modeling/tests/test_compound.py
+++ b/astropy/modeling/tests/test_compound.py
@@ -553,3 +553,11 @@ def test_bounding_box():
     val2 = g(x+2, y+2, with_bounding_box=True)
     assert(np.isnan(val2).sum() == 100)
     val3 = g(.1, .1, with_bounding_box=True)
+
+
+def test_bounding_box_with_units():
+    points = np.arange(5) * u.pix
+    lt = np.arange(5) * u.AA
+    t = Tabular1D(points, lt)
+
+    assert(t(1 * u.pix, with_bounding_box=True) == 1. * u.AA)

--- a/astropy/modeling/tests/test_quantities_evaluation.py
+++ b/astropy/modeling/tests/test_quantities_evaluation.py
@@ -42,7 +42,7 @@ def test_evaluate_with_quantities():
     # error is raised
     with pytest.raises(UnitsError) as exc:
         gq(1)
-    assert exc.value.args[0] == ("Units of input 'x', (dimensionless), could not be "
+    assert exc.value.args[0] == ("Gaussian1D: Units of input 'x', (dimensionless), could not be "
                                  "converted to required input units of m (length)")
 
     # However, zero is a special case
@@ -54,7 +54,7 @@ def test_evaluate_with_quantities():
     # But not with incompatible units
     with pytest.raises(UnitsError) as exc:
         gq(3 * u.s)
-    assert exc.value.args[0] == ("Units of input 'x', s (time), could not be "
+    assert exc.value.args[0] == ("Gaussian1D: Units of input 'x', s (time), could not be "
                                  "converted to required input units of m (length)")
 
     # We also can't evaluate the model without quantities with a quantity
@@ -75,7 +75,7 @@ def test_evaluate_with_quantities_and_equivalencies():
     # We aren't setting the equivalencies, so this won't work
     with pytest.raises(UnitsError) as exc:
         g(30 * u.PHz)
-    assert exc.value.args[0] == ("Units of input 'x', PHz (frequency), could "
+    assert exc.value.args[0] == ("Gaussian1D: Units of input 'x', PHz (frequency), could "
                                  "not be converted to required input units of "
                                  "nm (length)")
 
@@ -115,12 +115,12 @@ class TestInputUnits():
 
         with pytest.raises(UnitsError) as exc:
             self.model(4 * u.s, 3)
-        assert exc.value.args[0] == ("Units of input 'a', s (time), could not be "
+        assert exc.value.args[0] == ("MyTestModel: Units of input 'a', s (time), could not be "
                                      "converted to required input units of deg (angle)")
 
         with pytest.raises(UnitsError) as exc:
             self.model(3, 3)
-        assert exc.value.args[0] == ("Units of input 'a', (dimensionless), could "
+        assert exc.value.args[0] == ("MyTestModel: Units of input 'a', (dimensionless), could "
                                      "not be converted to required input units of deg (angle)")
 
     def test_input_units_allow_dimensionless(self):
@@ -133,7 +133,7 @@ class TestInputUnits():
 
         with pytest.raises(UnitsError) as exc:
             self.model(4 * u.s, 3)
-        assert exc.value.args[0] == ("Units of input 'a', s (time), could not be "
+        assert exc.value.args[0] == ("MyTestModel: Units of input 'a', s (time), could not be "
                                      "converted to required input units of deg (angle)")
 
         assert_quantity_allclose(self.model(3, 3), 9)
@@ -155,7 +155,7 @@ class TestInputUnits():
 
         with pytest.raises(UnitsError) as exc:
             self.model(3 * u.PHz, 3)
-        assert exc.value.args[0] == ("Units of input 'a', PHz (frequency), could "
+        assert exc.value.args[0] == ("MyTestModel: Units of input 'a', PHz (frequency), could "
                                      "not be converted to required input units of "
                                      "micron (length)")
 
@@ -314,7 +314,7 @@ def test_compound_input_units_equivalencies():
 
     with pytest.raises(UnitsError) as exc:
         out = cs(20 * u.pix, 10 * u.pix)
-    assert exc.value.args[0] == "Units of input 'x', pix (unknown), could not be converted to required input units of deg (angle)"
+    assert exc.value.args[0] == "Shift: Units of input 'x', pix (unknown), could not be converted to required input units of deg (angle)"
 
 
 def test_compound_input_units_strict():
@@ -370,7 +370,8 @@ def test_compound_input_units_allow_dimensionless():
 
     with pytest.raises(UnitsError) as exc:
         out = cs(10 * u.m)
-    assert exc.value.args[0] == "Units of input 'x', m (length), could not be converted to required input units of deg (angle)"
+    assert exc.value.args[0] == ("ScaleDegrees: Units of input 'x', m (length), "
+                                 "could not be converted to required input units of deg (angle)")
 
     s1._input_units_allow_dimensionless = False
 
@@ -379,7 +380,8 @@ def test_compound_input_units_allow_dimensionless():
 
     with pytest.raises(UnitsError) as exc:
         out = cs(10)
-    assert exc.value.args[0] == "Units of input 'x', (dimensionless), could not be converted to required input units of deg (angle)"
+    assert exc.value.args[0] == ("ScaleDegrees: Units of input 'x', (dimensionless), "
+                                 "could not be converted to required input units of deg (angle)")
 
     s1._input_units_allow_dimensionless = True
 
@@ -394,7 +396,8 @@ def test_compound_input_units_allow_dimensionless():
 
     with pytest.raises(UnitsError) as exc:
         out = cs(10 * u.m)
-    assert exc.value.args[0] == "Units of input 'x', m (length), could not be converted to required input units of deg (angle)"
+    assert exc.value.args[0] == ("ScaleDegrees: Units of input 'x', m (length), "
+                                 "could not be converted to required input units of deg (angle)")
 
     s1._input_units_allow_dimensionless = False
 
@@ -402,7 +405,8 @@ def test_compound_input_units_allow_dimensionless():
 
     with pytest.raises(UnitsError) as exc:
         out = cs(10)
-    assert exc.value.args[0] == "Units of input 'x', (dimensionless), could not be converted to required input units of deg (angle)"
+    assert exc.value.args[0] == ("ScaleDegrees: Units of input 'x', (dimensionless), "
+                                 "could not be converted to required input units of deg (angle)")
 
     s1._input_units_allow_dimensionless = True
 
@@ -420,7 +424,8 @@ def test_compound_input_units_allow_dimensionless():
 
     with pytest.raises(UnitsError) as exc:
         out = cs(10, 10)
-    assert exc.value.args[0] == "Units of input 'x', (dimensionless), could not be converted to required input units of deg (angle)"
+    assert exc.value.args[0] == ("ScaleDegrees: Units of input 'x', (dimensionless), "
+                                 "could not be converted to required input units of deg (angle)")
 
 
 def test_compound_return_units():

--- a/docs/modeling/compound-models.rst
+++ b/docs/modeling/compound-models.rst
@@ -562,14 +562,15 @@ subexpression ``B * C``::
     the compound model). So::
 
         m1 * m2
-    
+
     is a submodel (i.e.,``m[:2]``) but
     ``m[1:3]`` is not. Currently this also means that in simpler expressions
     such as::
+
         m = m1 + m2 + m3 + m4
 
     where any slice should be valid in
-    principle, only slices that include m1 are since it is part of 
+    principle, only slices that include m1 are since it is part of
     all submodules (since the order of evaluation is::
 
         ((m1 + m2) + m3) + m4


### PR DESCRIPTION
Changes in this PR:

- Adds the name of the model to the error message (I find it very useful)
- Removes several unused variables
- Fixes a few unddefined variables (missing `self.`)
- Adds back a test which disappeared somehow (during rebasing?)
- Fixes the Travis documentation build error